### PR TITLE
fix: Update CI to Node 20 for ESM compatibility

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,7 +18,7 @@ on:
         default: false
 
 env:
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   AWS_REGION: 'us-east-1'
   S3_BUCKET_PRODUCTION: 's3://picassocode/'
   S3_BUCKET_STAGING: 's3://picassostaging/'


### PR DESCRIPTION
## Summary
- Update CI Node version from 18 to 20
- Fixes all 12 test suites failing with `You appear to be using a native ECMAScript module configuration file`
- Node 20 matches the Lambda runtime version

## Test plan
- [ ] CI test suite runs (was 12/12 failing, should now pass)
- [ ] Staging deploy succeeds
- [ ] Approval gate appears before production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)