### PR TITLE
fix: Bump widget bundle size limit to 25KB

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -198,9 +198,9 @@ jobs:
           echo "Widget size: $((WIDGET_SIZE / 1024))KB"
           echo "Iframe size: $((IFRAME_SIZE / 1024))KB"
 
-          # Fail if widget exceeds 20KB (gzipped should be ~5KB)
-          if [ $WIDGET_SIZE -gt 20480 ]; then
-            echo "ERROR: Widget size exceeds 20KB limit"
+          # Fail if widget exceeds 25KB (gzipped should be ~6KB)
+          if [ $WIDGET_SIZE -gt 25600 ]; then
+            echo "ERROR: Widget size exceeds 25KB limit"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
Widget grew from ~19KB to 22KB after P12 security fix (iframeOrigin storage). Bumps CI limit from 20KB to 25KB.

## Test plan
- [ ] CI pipeline passes all jobs including Performance Evaluation
- [ ] Staging deploy runs
- [ ] Approval gate appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)