### PR TITLE
fix: Deploy job needs contents:write for git tags

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -351,7 +351,7 @@ jobs:
       url: https://chat.myrecruiter.ai
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Deploy job failed pushing deployment tag — needs `contents: write` (was `read`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)