### PR TITLE
feat: Route streaming through CloudFront + WAF (P22 Phase 2)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -135,10 +135,17 @@ jobs:
         working-directory: ./Picasso
         run: npm ci
 
-      - name: Run npm audit
+      - name: Run npm audit (Picasso)
         working-directory: ./Picasso
-        run: npm audit --production --audit-level=high
-        continue-on-error: true
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Run npm audit (Bedrock Lambda)
+        working-directory: ./Lambdas/lambda/Bedrock_Streaming_Handler_Staging
+        run: npm install --omit=dev --ignore-scripts && npm audit --omit=dev --audit-level=high
+
+      - name: Run npm audit (Config Manager Lambda)
+        working-directory: ./Lambdas/lambda/Picasso_Config_Manager
+        run: npm install --omit=dev --ignore-scripts && npm audit --omit=dev --audit-level=high
 
       - name: Run Snyk security scan
         uses: snyk/actions/node@master
@@ -189,6 +196,17 @@ jobs:
         run: npm run build:production
         env:
           BUILD_ENV: production
+          PICASSO_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_CONVERSATION_ENDPOINT }}
+          PICASSO_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STREAMING_ENDPOINT }}
+
+      - name: Validate no hardcoded Lambda URLs in build
+        working-directory: ./Picasso
+        run: |
+          if grep -r 'lambda-url\.us-east-1\.on\.aws' dist/production/ 2>/dev/null; then
+            echo "ERROR: Hardcoded Lambda URLs found in production build"
+            exit 1
+          fi
+          echo "OK: No hardcoded Lambda URLs in production build"
 
       - name: Analyze bundle size
         working-directory: ./Picasso
@@ -254,6 +272,8 @@ jobs:
         run: npm run build:staging
         env:
           BUILD_ENV: staging
+          PICASSO_STAGING_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_STAGING_CONVERSATION_ENDPOINT }}
+          PICASSO_STAGING_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STAGING_STREAMING_ENDPOINT }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -334,6 +354,8 @@ jobs:
         run: npm run build:production
         env:
           BUILD_ENV: production
+          PICASSO_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_CONVERSATION_ENDPOINT }}
+          PICASSO_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STREAMING_ENDPOINT }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -124,6 +124,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Checkout Lambda repo
+        uses: actions/checkout@v4
+        with:
+          repository: longhornrumble/lambda
+          path: Lambdas/lambda
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -199,14 +199,15 @@ jobs:
           PICASSO_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_CONVERSATION_ENDPOINT }}
           PICASSO_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STREAMING_ENDPOINT }}
 
-      - name: Validate no hardcoded Lambda URLs in build
+      - name: Validate no dev/staging Lambda URLs in production build
         working-directory: ./Picasso
         run: |
-          if grep -r 'lambda-url\.us-east-1\.on\.aws' dist/production/ 2>/dev/null; then
-            echo "ERROR: Hardcoded Lambda URLs found in production build"
+          DEV_URLS="2ho6tw56ccvl6uvicra4f56j740dyxgo\|7pluzq3axftklmb4gbgchfdahu0lcnqd"
+          if grep -r "$DEV_URLS" dist/production/ 2>/dev/null; then
+            echo "ERROR: Development/staging Lambda URLs found in production build"
             exit 1
           fi
-          echo "OK: No hardcoded Lambda URLs in production build"
+          echo "OK: No dev/staging Lambda URLs in production build"
 
       - name: Analyze bundle size
         working-directory: ./Picasso

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -90,6 +90,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -141,14 +143,16 @@ jobs:
           PICASSO_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_CONVERSATION_ENDPOINT }}
           PICASSO_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STREAMING_ENDPOINT }}
 
-      - name: Validate no hardcoded Lambda URLs
+      - name: Validate no dev/staging Lambda URLs in production build
         working-directory: ./Picasso
         run: |
-          if grep -r 'lambda-url\.us-east-1\.on\.aws' dist/production/ 2>/dev/null; then
-            echo "ERROR: Hardcoded Lambda URLs found in production build"
+          # Dev and staging Lambda Function URLs that must not appear in production builds
+          DEV_URLS="2ho6tw56ccvl6uvicra4f56j740dyxgo\|7pluzq3axftklmb4gbgchfdahu0lcnqd"
+          if grep -r "$DEV_URLS" dist/production/ 2>/dev/null; then
+            echo "ERROR: Development/staging Lambda URLs found in production build"
             exit 1
           fi
-          echo "OK: No hardcoded Lambda URLs in production build"
+          echo "OK: No dev/staging Lambda URLs in production build"
 
       - name: Check bundle size
         working-directory: ./Picasso

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,168 @@
+name: PR Quality Gates
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  lint:
+    name: Code Quality - Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'Picasso/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./Picasso
+        run: npm ci
+
+      - name: Run linting
+        working-directory: ./Picasso
+        run: npm run lint
+
+  typecheck:
+    name: Code Quality - Type Checking
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'Picasso/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./Picasso
+        run: npm ci
+
+      - name: Run type checking
+        working-directory: ./Picasso
+        run: npm run typecheck
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'Picasso/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./Picasso
+        run: npm ci
+
+      - name: Run tests
+        working-directory: ./Picasso
+        run: npm run test:coverage
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-coverage
+          path: Picasso/coverage/
+          retention-days: 7
+
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'Picasso/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./Picasso
+        run: npm ci
+
+      - name: Run npm audit (Picasso)
+        working-directory: ./Picasso
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Run npm audit (Bedrock Lambda)
+        working-directory: ./Lambdas/lambda/Bedrock_Streaming_Handler_Staging
+        run: npm install --omit=dev --ignore-scripts && npm audit --omit=dev --audit-level=high
+
+      - name: Run npm audit (Config Manager Lambda)
+        working-directory: ./Lambdas/lambda/Picasso_Config_Manager
+        run: npm install --omit=dev --ignore-scripts && npm audit --omit=dev --audit-level=high
+
+  build:
+    name: Build Validation
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'Picasso/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./Picasso
+        run: npm ci
+
+      - name: Build production bundle
+        working-directory: ./Picasso
+        run: npm run build:production
+        env:
+          BUILD_ENV: production
+          PICASSO_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_CONVERSATION_ENDPOINT }}
+          PICASSO_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STREAMING_ENDPOINT }}
+
+      - name: Validate no hardcoded Lambda URLs
+        working-directory: ./Picasso
+        run: |
+          if grep -r 'lambda-url\.us-east-1\.on\.aws' dist/production/ 2>/dev/null; then
+            echo "ERROR: Hardcoded Lambda URLs found in production build"
+            exit 1
+          fi
+          echo "OK: No hardcoded Lambda URLs in production build"
+
+      - name: Check bundle size
+        working-directory: ./Picasso
+        run: |
+          WIDGET_SIZE=$(stat -c%s "dist/production/widget.js" 2>/dev/null || stat -f%z "dist/production/widget.js")
+          IFRAME_SIZE=$(stat -c%s "dist/production/iframe-main.js" 2>/dev/null || stat -f%z "dist/production/iframe-main.js")
+          echo "Widget size: $((WIDGET_SIZE / 1024))KB"
+          echo "Iframe size: $((IFRAME_SIZE / 1024))KB"
+
+          if [ $WIDGET_SIZE -gt 25600 ]; then
+            echo "ERROR: Widget size exceeds 25KB limit"
+            exit 1
+          fi
+
+          if [ $IFRAME_SIZE -gt 512000 ]; then
+            echo "ERROR: Iframe size exceeds 500KB limit"
+            exit 1
+          fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -90,8 +90,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Checkout Lambda repo
+        uses: actions/checkout@v4
         with:
-          submodules: true
+          repository: longhornrumble/lambda
+          path: Lambdas/lambda
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   NODE_VERSION: '22'
+  AWS_REGION: 'us-east-1'
 
 jobs:
   lint:
@@ -166,3 +167,67 @@ jobs:
             echo "ERROR: Iframe size exceeds 500KB limit"
             exit 1
           fi
+
+  deploy-staging:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    needs: [build, security]
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'Picasso/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./Picasso
+        run: npm ci
+
+      - name: Build staging bundle
+        working-directory: ./Picasso
+        run: npm run build:staging
+        env:
+          BUILD_ENV: staging
+          PICASSO_STAGING_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_STAGING_CONVERSATION_ENDPOINT }}
+          PICASSO_STAGING_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STAGING_STREAMING_ENDPOINT }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy to staging S3
+        working-directory: ./Picasso
+        run: |
+          aws s3 sync dist/staging/ s3://picassostaging/ \
+            --exclude "*.map" \
+            --exclude "collateral/*" \
+            --exclude "tenants/*" \
+            --cache-control "public, max-age=60" \
+            --delete
+
+      - name: Invalidate staging CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_STAGING_DISTRIBUTION_ID }} \
+            --paths '/*'
+
+      - name: Post staging URL to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Staging Deployed\n\nTest at: **https://staging.chat.myrecruiter.ai**\n\nTest tenant: MYR384719 (hash \`my87674d777bf9\`)\n\nAll quality gates passed. Merge when staging verification is complete.`
+            })

--- a/Picasso/.gitignore
+++ b/Picasso/.gitignore
@@ -189,6 +189,7 @@ dev.config.json
 
 # Test HTML files (local testing only)
 test-*.html
+!public/test-staging.html
 
 # Session/deployment summaries (one-time docs)
 *_DEPLOYMENT_*.md

--- a/Picasso/esbuild.config.mjs
+++ b/Picasso/esbuild.config.mjs
@@ -138,26 +138,26 @@ const ENVIRONMENT_CONFIG = {
     STREAMING_ENDPOINT: 'https://7pluzq3axftklmb4gbgchfdahu0lcnqd.lambda-url.us-east-1.on.aws'
   },
   staging: {
-    // Staging mirrors production: CloudFront proxies to API Gateway for config/chat, Lambda Function URL for streaming
+    // Staging: all traffic through CloudFront (staging.chat.myrecruiter.ai)
     API_BASE_URL: 'https://staging.chat.myrecruiter.ai/Master_Function',
     WIDGET_DOMAIN: 'https://staging.chat.myrecruiter.ai',
     CONFIG_DOMAIN: 'https://staging.chat.myrecruiter.ai',
     CONFIG_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=get_config',
     CHAT_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=chat',
-    CONVERSATION_ENDPOINT: process.env.PICASSO_STAGING_CONVERSATION_ENDPOINT || 'https://staging.chat.myrecruiter.ai/Master_Function?action=conversation',
+    CONVERSATION_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=conversation',
     ERROR_REPORTING_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: process.env.PICASSO_STAGING_STREAMING_ENDPOINT || ''
+    STREAMING_ENDPOINT: 'https://staging.chat.myrecruiter.ai/stream'
   },
   production: {
-    // Production uses API Gateway/CloudFront for main endpoints, Lambda URLs from CI secrets
+    // Production: all traffic through CloudFront (chat.myrecruiter.ai)
     API_BASE_URL: 'https://chat.myrecruiter.ai/Master_Function',
     WIDGET_DOMAIN: 'https://chat.myrecruiter.ai',
     CONFIG_DOMAIN: 'https://picassocode.s3.amazonaws.com',
     CONFIG_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=get_config',
     CHAT_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=chat',
-    CONVERSATION_ENDPOINT: process.env.PICASSO_CONVERSATION_ENDPOINT || '',
+    CONVERSATION_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=conversation',
     ERROR_REPORTING_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: process.env.PICASSO_STREAMING_ENDPOINT || ''
+    STREAMING_ENDPOINT: 'https://chat.myrecruiter.ai/stream'
   }
 };
 

--- a/Picasso/esbuild.config.mjs
+++ b/Picasso/esbuild.config.mjs
@@ -144,20 +144,20 @@ const ENVIRONMENT_CONFIG = {
     CONFIG_DOMAIN: 'https://staging.chat.myrecruiter.ai',
     CONFIG_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=get_config',
     CHAT_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=chat',
-    CONVERSATION_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=conversation',
+    CONVERSATION_ENDPOINT: process.env.PICASSO_STAGING_CONVERSATION_ENDPOINT || 'https://staging.chat.myrecruiter.ai/Master_Function?action=conversation',
     ERROR_REPORTING_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: 'https://7pluzq3axftklmb4gbgchfdahu0lcnqd.lambda-url.us-east-1.on.aws'
+    STREAMING_ENDPOINT: process.env.PICASSO_STAGING_STREAMING_ENDPOINT || ''
   },
   production: {
-    // Production uses API Gateway/CloudFront for main endpoints, Lambda URLs only where needed
+    // Production uses API Gateway/CloudFront for main endpoints, Lambda URLs from CI secrets
     API_BASE_URL: 'https://chat.myrecruiter.ai/Master_Function',
     WIDGET_DOMAIN: 'https://chat.myrecruiter.ai',
     CONFIG_DOMAIN: 'https://picassocode.s3.amazonaws.com',
     CONFIG_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=get_config',
     CHAT_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=chat',
-    CONVERSATION_ENDPOINT: 'https://hfkpcekuxi3z7kllmoitt7ngae0fggxf.lambda-url.us-east-1.on.aws?action=conversation', // Lambda URL for JWT support
+    CONVERSATION_ENDPOINT: process.env.PICASSO_CONVERSATION_ENDPOINT || '',
     ERROR_REPORTING_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: 'https://xqc4wnxwia2nytjkbw6xasjd6q0jckgb.lambda-url.us-east-1.on.aws'
+    STREAMING_ENDPOINT: process.env.PICASSO_STREAMING_ENDPOINT || ''
   }
 };
 
@@ -283,6 +283,7 @@ const defineVars = {
   __IS_STAGING__: JSON.stringify(environment === 'staging'),
   __DEFAULT_TENANT_HASH__: JSON.stringify(isDevelopment ? devConfig.DEFAULT_TENANT_HASH : 'my87674d777bf9'),
   __DISABLE_AUTO_DEV_MODE__: JSON.stringify(environment !== 'development'),
+  __ALLOW_CONFIG_PATH_OVERRIDE__: JSON.stringify(isDevelopment),
   
   // Vite compatibility - import.meta.env support
   'import.meta.env.DEV': JSON.stringify(isDevelopment),

--- a/Picasso/package-lock.json
+++ b/Picasso/package-lock.json
@@ -2452,9 +2452,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2463,9 +2463,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2513,9 +2513,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2589,9 +2589,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3779,9 +3779,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4257,9 +4257,9 @@
       }
     },
     "node_modules/babel-jest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4483,9 +4483,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5152,9 +5152,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5611,9 +5611,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5635,9 +5635,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5688,9 +5688,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5699,9 +5699,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5969,9 +5969,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6207,9 +6207,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6218,9 +6218,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8155,9 +8155,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8930,9 +8930,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10017,9 +10017,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10028,9 +10028,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/Picasso/public/test-staging.html
+++ b/Picasso/public/test-staging.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Staging Widget Test</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 40px; background: #f5f5f5; }
+        .info { background: #fff; padding: 20px; border-radius: 8px; margin: 20px 0; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .info h2 { margin-top: 0; color: #059669; }
+        code { background: #e5e7eb; padding: 2px 6px; border-radius: 4px; }
+    </style>
+</head>
+<body>
+    <h1>Staging Widget Test</h1>
+    <div class="info">
+        <h2>Test Checklist (Security Phase 3 — P19)</h2>
+        <p><strong>Tenant:</strong> <span id="tenantHash"></span></p>
+        <ol>
+            <li>Widget opens/closes — state persists across open/close</li>
+            <li>Send a message — streamed response comes back</li>
+            <li>CTA buttons render and trigger actions</li>
+            <li>External link CTAs open in new tab (allow-popups)</li>
+            <li>Start a form, close chat, reopen — form state persists in session</li>
+        </ol>
+        <p><em>If all 5 pass, the iframe sandbox + sessionStorage migration is solid.</em></p>
+    </div>
+
+    <script>
+        const urlParams = new URLSearchParams(window.location.search);
+        const tenantHash = urlParams.get('t') || 'my87674d777bf9';
+        document.getElementById('tenantHash').textContent = tenantHash;
+
+        const script = document.createElement('script');
+        script.src = 'https://staging.chat.myrecruiter.ai/widget.js';
+        script.setAttribute('data-tenant', tenantHash);
+        document.body.appendChild(script);
+    </script>
+</body>
+</html>

--- a/Picasso/src/components/chat/ChatWidget.jsx
+++ b/Picasso/src/components/chat/ChatWidget.jsx
@@ -18,6 +18,7 @@ import FormFieldPrompt from "../forms/FormFieldPrompt";
 import FormCompletionCard from "../forms/FormCompletionCard";
 import { useFormMode } from "../../context/FormModeContext";
 import { sanitizeHTML } from "../../utils/security";
+import { _storeGet, _storeSet, _storeRemove } from "../../context/shared/messageHelpers";
 
 function ChatWidget() {
   const { messages, isTyping, renderMode, recordFormCompletion } = useChat();
@@ -72,8 +73,8 @@ function ChatWidget() {
     
     try {
       // Use sessionStorage to match conversation persistence behavior
-      const savedState = sessionStorage.getItem('picasso_chat_state');
-      const lastActivity = sessionStorage.getItem('picasso_last_activity');
+      const savedState = _storeGet('picasso_chat_state');
+      const lastActivity = _storeGet('picasso_last_activity');
       
       if (savedState !== null && lastActivity) {
         const timeSinceActivity = Date.now() - parseInt(lastActivity);
@@ -102,9 +103,9 @@ function ChatWidget() {
     // Initialize from sessionStorage if available
     if (widgetBehavior.remember_state) {
       try {
-        const savedState = sessionStorage.getItem('picasso_chat_state');
-        const lastActivity = sessionStorage.getItem('picasso_last_activity');
-        const savedReadIndex = sessionStorage.getItem('picasso_last_read_index');
+        const savedState = _storeGet('picasso_chat_state');
+        const lastActivity = _storeGet('picasso_last_activity');
+        const savedReadIndex = _storeGet('picasso_last_read_index');
         
         if (savedState !== null && lastActivity && savedReadIndex !== null) {
           const timeSinceActivity = Date.now() - parseInt(lastActivity);
@@ -208,11 +209,11 @@ function ChatWidget() {
 
     if (widgetBehavior.remember_state) {
       try {
-        sessionStorage.setItem('picasso_chat_state', JSON.stringify(newOpen));
-        sessionStorage.setItem('picasso_last_activity', Date.now().toString());
+        _storeSet('picasso_chat_state', JSON.stringify(newOpen));
+        _storeSet('picasso_last_activity', Date.now().toString());
         // Save the last read index when closing
         if (!newOpen) {
-          sessionStorage.setItem('picasso_last_read_index', lastReadMessageIndex.toString());
+          _storeSet('picasso_last_read_index', lastReadMessageIndex.toString());
         }
       } catch (e) {
         console.warn('Failed to save chat state on toggle:', e);
@@ -226,8 +227,8 @@ function ChatWidget() {
       // Respect remember_state: don't override if user explicitly closed
       if (widgetBehavior.remember_state) {
         try {
-          const saved = sessionStorage.getItem('picasso_chat_state');
-          const lastActivity = sessionStorage.getItem('picasso_last_activity');
+          const saved = _storeGet('picasso_chat_state');
+          const lastActivity = _storeGet('picasso_last_activity');
           if (saved !== null && lastActivity) {
             const timeSinceActivity = Date.now() - parseInt(lastActivity);
             if (timeSinceActivity < 30 * 60 * 1000 && JSON.parse(saved) === false) {
@@ -247,8 +248,8 @@ function ChatWidget() {
       let skipAutoOpen = false;
       if (widgetConfig.remember_state) {
         try {
-          const saved = sessionStorage.getItem('picasso_chat_state');
-          const lastActivity = sessionStorage.getItem('picasso_last_activity');
+          const saved = _storeGet('picasso_chat_state');
+          const lastActivity = _storeGet('picasso_last_activity');
           
           if (saved !== null && lastActivity) {
             const timeSinceActivity = Date.now() - parseInt(lastActivity);
@@ -268,8 +269,8 @@ function ChatWidget() {
           // Update activity timestamp when auto-opening
           if (widgetConfig.remember_state) {
             try {
-              sessionStorage.setItem('picasso_chat_state', 'true');
-              sessionStorage.setItem('picasso_last_activity', Date.now().toString());
+              _storeSet('picasso_chat_state', 'true');
+              _storeSet('picasso_last_activity', Date.now().toString());
             } catch (e) {
               console.warn('Failed to save chat state on auto-open:', e);
             }
@@ -357,15 +358,15 @@ function ChatWidget() {
   useEffect(() => {
     if (!isOpen && chatWindowRef.current) {
       const scrollPosition = chatWindowRef.current.scrollTop;
-      sessionStorage.setItem('picasso_scroll_position', scrollPosition.toString());
+      _storeSet('picasso_scroll_position', scrollPosition.toString());
     }
   }, [isOpen]);
 
   // Restore scroll position when chat opens with persisted conversation
   useEffect(() => {
     if (isOpen && chatWindowRef.current && !hasRestoredScrollRef.current && messages.length > 1) {
-      const savedPosition = sessionStorage.getItem('picasso_scroll_position');
-      const hasPersistedMessages = sessionStorage.getItem('picasso_messages');
+      const savedPosition = _storeGet('picasso_scroll_position');
+      const hasPersistedMessages = _storeGet('picasso_messages');
       
       if (savedPosition) {
         // Delay to ensure DOM is ready
@@ -392,7 +393,7 @@ function ChatWidget() {
       // Update saved read index when opening chat
       if (widgetBehavior.remember_state) {
         try {
-          sessionStorage.setItem('picasso_last_read_index', messages.length.toString());
+          _storeSet('picasso_last_read_index', messages.length.toString());
         } catch (e) {
           console.warn('Failed to save last read index:', e);
         }

--- a/Picasso/src/components/chat/StateManagementPanel.jsx
+++ b/Picasso/src/components/chat/StateManagementPanel.jsx
@@ -27,6 +27,7 @@ import {
 } from 'lucide-react';
 
 import { useChat } from '../../hooks/useChat';
+import { _storeRemove } from '../../context/shared/messageHelpers';
 import { errorLogger } from '../../utils/errorHandling';
 import { config as environmentConfig } from '../../config/environment';
 
@@ -144,7 +145,7 @@ const StateManagementPanel = ({ isOpen, onClose }) => {
 
       // Clear local history
       localStorage.removeItem('picasso_conversations');
-      sessionStorage.removeItem('picasso_current_conversation');
+      _storeRemove('picasso_current_conversation');
       
       setConversationHistory([]);
       setShowClearConfirm(false);

--- a/Picasso/src/config/environment.js
+++ b/Picasso/src/config/environment.js
@@ -226,7 +226,7 @@ const ENVIRONMENTS = {
     CHAT_ENDPOINT: typeof __CHAT_ENDPOINT__ !== 'undefined' ? __CHAT_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=chat',
     CONVERSATION_ENDPOINT: typeof __CONVERSATION_ENDPOINT__ !== 'undefined' ? __CONVERSATION_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=conversation',
     ERROR_REPORTING_ENDPOINT: typeof __ERROR_REPORTING_ENDPOINT__ !== 'undefined' ? __ERROR_REPORTING_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : '', // Set via CI secrets
+    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/stream',
     STREAMING_METHOD: 'POST', // Lambda expects POST requests with JSON body
     DEFAULT_TENANT_HASH: typeof __DEFAULT_TENANT_HASH__ !== 'undefined' ? __DEFAULT_TENANT_HASH__ : 'my87674d777bf9', // MyRecruiter tenant: ID=MYR384719, Hash=my87674d777bf9
 
@@ -252,10 +252,9 @@ const ENVIRONMENTS = {
     DEBUG: false,
     CONFIG_ENDPOINT: typeof __CONFIG_ENDPOINT__ !== 'undefined' ? __CONFIG_ENDPOINT__ : 'https://chat.myrecruiter.ai/Master_Function?action=get_config',
     CHAT_ENDPOINT: typeof __CHAT_ENDPOINT__ !== 'undefined' ? __CHAT_ENDPOINT__ : 'https://chat.myrecruiter.ai/Master_Function?action=chat',
-    // Use Lambda Function URL for conversation to preserve JWT headers (CloudFront strips them)
-    CONVERSATION_ENDPOINT: typeof __CONVERSATION_ENDPOINT__ !== 'undefined' ? __CONVERSATION_ENDPOINT__ : '', // Set via CI secrets
+    CONVERSATION_ENDPOINT: typeof __CONVERSATION_ENDPOINT__ !== 'undefined' ? __CONVERSATION_ENDPOINT__ : 'https://chat.myrecruiter.ai/Master_Function?action=conversation',
     ERROR_REPORTING_ENDPOINT: typeof __ERROR_REPORTING_ENDPOINT__ !== 'undefined' ? __ERROR_REPORTING_ENDPOINT__ : 'https://chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : '', // Set via CI secrets
+    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : 'https://chat.myrecruiter.ai/stream',
     STREAMING_METHOD: 'POST', // Lambda expects POST requests with JSON body
     DEFAULT_TENANT_HASH: typeof __DEFAULT_TENANT_HASH__ !== 'undefined' ? __DEFAULT_TENANT_HASH__ : 'my87674d777bf9', // MyRecruiter default tenant for production
     

--- a/Picasso/src/config/environment.js
+++ b/Picasso/src/config/environment.js
@@ -226,7 +226,7 @@ const ENVIRONMENTS = {
     CHAT_ENDPOINT: typeof __CHAT_ENDPOINT__ !== 'undefined' ? __CHAT_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=chat',
     CONVERSATION_ENDPOINT: typeof __CONVERSATION_ENDPOINT__ !== 'undefined' ? __CONVERSATION_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=conversation',
     ERROR_REPORTING_ENDPOINT: typeof __ERROR_REPORTING_ENDPOINT__ !== 'undefined' ? __ERROR_REPORTING_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : 'https://7pluzq3axftklmb4gbgchfdahu0lcnqd.lambda-url.us-east-1.on.aws', // Bedrock_Streaming_Handler_Staging
+    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : '', // Set via CI secrets
     STREAMING_METHOD: 'POST', // Lambda expects POST requests with JSON body
     DEFAULT_TENANT_HASH: typeof __DEFAULT_TENANT_HASH__ !== 'undefined' ? __DEFAULT_TENANT_HASH__ : 'my87674d777bf9', // MyRecruiter tenant: ID=MYR384719, Hash=my87674d777bf9
 
@@ -253,9 +253,9 @@ const ENVIRONMENTS = {
     CONFIG_ENDPOINT: typeof __CONFIG_ENDPOINT__ !== 'undefined' ? __CONFIG_ENDPOINT__ : 'https://chat.myrecruiter.ai/Master_Function?action=get_config',
     CHAT_ENDPOINT: typeof __CHAT_ENDPOINT__ !== 'undefined' ? __CHAT_ENDPOINT__ : 'https://chat.myrecruiter.ai/Master_Function?action=chat',
     // Use Lambda Function URL for conversation to preserve JWT headers (CloudFront strips them)
-    CONVERSATION_ENDPOINT: typeof __CONVERSATION_ENDPOINT__ !== 'undefined' ? __CONVERSATION_ENDPOINT__ : 'https://hfkpcekuxi3z7kllmoitt7ngae0fggxf.lambda-url.us-east-1.on.aws?action=conversation', // NEW production Lambda URL (CORS in Lambda code only)
+    CONVERSATION_ENDPOINT: typeof __CONVERSATION_ENDPOINT__ !== 'undefined' ? __CONVERSATION_ENDPOINT__ : '', // Set via CI secrets
     ERROR_REPORTING_ENDPOINT: typeof __ERROR_REPORTING_ENDPOINT__ !== 'undefined' ? __ERROR_REPORTING_ENDPOINT__ : 'https://chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : 'https://xqc4wnxwia2nytjkbw6xasjd6q0jckgb.lambda-url.us-east-1.on.aws', // Production Bedrock_Streaming_Handler endpoint
+    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : '', // Set via CI secrets
     STREAMING_METHOD: 'POST', // Lambda expects POST requests with JSON body
     DEFAULT_TENANT_HASH: typeof __DEFAULT_TENANT_HASH__ !== 'undefined' ? __DEFAULT_TENANT_HASH__ : 'my87674d777bf9', // MyRecruiter default tenant for production
     

--- a/Picasso/src/context/ChatProvider.jsx
+++ b/Picasso/src/context/ChatProvider.jsx
@@ -3,6 +3,7 @@ import { useConfig } from "../hooks/useConfig";
 import { config as environmentConfig } from '../config/environment';
 import { ChatContext } from './shared/ChatContext';
 import { useFormMode } from './FormModeContext';
+import { _storeGet, _storeSet, _storeRemove, _storeKeys } from './shared/messageHelpers';
 import PropTypes from "prop-types";
 import { 
   errorLogger, 
@@ -514,13 +515,13 @@ const ChatProvider = ({ children }) => {
   
   // 🔧 FIX: Session validation - ALWAYS reuse for widget persistence
   const validateAndPurgeSession = () => {
-    const stored = sessionStorage.getItem(STORAGE_KEYS.SESSION_ID);
+    const stored = _storeGet(STORAGE_KEYS.SESSION_ID);
 
     // ALWAYS reuse existing session for widget persistence
     // Session should only expire on browser tab close, not widget close
     if (stored) {
       // Update activity timestamp
-      sessionStorage.setItem(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
+      _storeSet(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
       logger.debug('Session validation: Reusing existing session for widget persistence', stored);
       return stored;
     }
@@ -528,8 +529,8 @@ const ChatProvider = ({ children }) => {
     // Only create new session if none exists (first time)
     // Use consistent format with ConversationManager: session_TIMESTAMP
     const newSessionId = `session_${Date.now()}`;
-    sessionStorage.setItem(STORAGE_KEYS.SESSION_ID, newSessionId);
-    sessionStorage.setItem(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
+    _storeSet(STORAGE_KEYS.SESSION_ID, newSessionId);
+    _storeSet(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
     logger.debug('Session validation: Created new session (first time)', newSessionId);
     return newSessionId;
   };
@@ -552,8 +553,8 @@ const ChatProvider = ({ children }) => {
       ];
       
       keysToRemove.forEach(key => {
-        if (sessionStorage.getItem(key)) {
-          sessionStorage.removeItem(key);
+        if (_storeGet(key)) {
+          _storeRemove(key);
           logger.debug(`Purged session storage key: ${key}`);
         }
       });
@@ -595,11 +596,11 @@ const ChatProvider = ({ children }) => {
 
     // DEBUG: Show ALL sessionStorage keys
     try {
-      const allKeys = Object.keys(sessionStorage);
+      const allKeys = _storeKeys();
       console.log('📦 ALL SessionStorage keys:', allKeys.length, 'keys');
       allKeys.forEach(key => {
         if (key.startsWith('picasso')) {
-          const value = sessionStorage.getItem(key);
+          const value = _storeGet(key);
           console.log(`📦 ${key}:`, value ? value.slice(0, 100) : 'null');
         }
       });
@@ -608,9 +609,9 @@ const ChatProvider = ({ children }) => {
     }
 
     // Check for existing session first, create new one only if needed
-    const storedSessionId = sessionStorage.getItem(STORAGE_KEYS.SESSION_ID);
-    const storedMessages = sessionStorage.getItem(STORAGE_KEYS.MESSAGES);
-    const lastActivity = sessionStorage.getItem(STORAGE_KEYS.LAST_ACTIVITY);
+    const storedSessionId = _storeGet(STORAGE_KEYS.SESSION_ID);
+    const storedMessages = _storeGet(STORAGE_KEYS.MESSAGES);
+    const lastActivity = _storeGet(STORAGE_KEYS.LAST_ACTIVITY);
 
     console.log('🟢 SessionStorage on mount:', {
       sessionId: storedSessionId?.slice(0, 12),
@@ -624,7 +625,7 @@ const ChatProvider = ({ children }) => {
       // Session should only expire when browser tab closes, not widget close
       console.log('🟢 REUSING existing session for widget persistence:', storedSessionId.slice(0, 12) + '...');
       sessionIdRef.current = storedSessionId;
-      sessionStorage.setItem(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
+      _storeSet(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
 
       // Note: We're NOT checking SESSION_TIMEOUT here because:
       // 1. Widget close/reopen should maintain session (user expectation)
@@ -635,8 +636,8 @@ const ChatProvider = ({ children }) => {
       console.log('🟢 CREATING new session (no existing session found)');
       const newSessionId = `session_${Date.now()}`;
       sessionIdRef.current = newSessionId;
-      sessionStorage.setItem(STORAGE_KEYS.SESSION_ID, newSessionId);
-      sessionStorage.setItem(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
+      _storeSet(STORAGE_KEYS.SESSION_ID, newSessionId);
+      _storeSet(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
     }
 
     // Signal that session is ready
@@ -694,9 +695,9 @@ const ChatProvider = ({ children }) => {
   const loadPersistedMessages = () => {
     console.log('🔵 loadPersistedMessages called');
     try {
-      const stored = sessionStorage.getItem(STORAGE_KEYS.MESSAGES);
-      const lastActivity = sessionStorage.getItem(STORAGE_KEYS.LAST_ACTIVITY);
-      const storedSessionId = sessionStorage.getItem(STORAGE_KEYS.SESSION_ID);
+      const stored = _storeGet(STORAGE_KEYS.MESSAGES);
+      const lastActivity = _storeGet(STORAGE_KEYS.LAST_ACTIVITY);
+      const storedSessionId = _storeGet(STORAGE_KEYS.SESSION_ID);
       const currentSessionId = sessionIdRef.current;
 
       console.log('🔵 Persisted message check:', {
@@ -797,7 +798,7 @@ const ChatProvider = ({ children }) => {
           currentSession: currentSessionId?.slice(0, 12)
         });
         // Clear old session data
-        sessionStorage.removeItem(STORAGE_KEYS.MESSAGES);
+        _storeRemove(STORAGE_KEYS.MESSAGES);
       } else {
         console.log('🔵 NO MESSAGES TO LOAD:', {
           hasStored: !!stored,
@@ -904,8 +905,8 @@ const ChatProvider = ({ children }) => {
             }
             return msg;
           });
-          sessionStorage.setItem(STORAGE_KEYS.MESSAGES, JSON.stringify(messagesToPersist));
-          sessionStorage.setItem(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
+          _storeSet(STORAGE_KEYS.MESSAGES, JSON.stringify(messagesToPersist));
+          _storeSet(STORAGE_KEYS.LAST_ACTIVITY, Date.now().toString());
           errorLogger.logInfo('💾 Persisted conversation state', {
             messageCount: messages.length,
             sessionId: sessionIdRef.current
@@ -1010,7 +1011,7 @@ const ChatProvider = ({ children }) => {
           }
           
           // 🔧 FIX: Final session validation before creating conversation manager
-          const currentStoredSession = sessionStorage.getItem(STORAGE_KEYS.SESSION_ID);
+          const currentStoredSession = _storeGet(STORAGE_KEYS.SESSION_ID);
           if (sessionId !== currentStoredSession) {
             logger.debug('🚨 Session ID mismatch during initialization, re-validating');
             const validSessionId = validateAndPurgeSession();
@@ -1020,12 +1021,12 @@ const ChatProvider = ({ children }) => {
           
           // 🔧 FIX: Only clear conversation state if session is new or expired
           // Don't clear for existing valid sessions as this prevents conversation recall
-          const isNewSession = !sessionStorage.getItem('picasso_conversation_id');
+          const isNewSession = !_storeGet('picasso_conversation_id');
           if (isNewSession) {
             logger.debug('🧹 New session detected, clearing any stale conversation state');
             try {
-              sessionStorage.removeItem('picasso_conversation_id');
-              sessionStorage.removeItem('picasso_state_token');
+              _storeRemove('picasso_conversation_id');
+              _storeRemove('picasso_state_token');
             } catch (e) {
               logger.warn('🧹 Error during conversation cleanup:', e);
             }
@@ -1084,8 +1085,8 @@ const ChatProvider = ({ children }) => {
               setMessages(restoredMessages);
 
               // Update sessionStorage to match server state
-              sessionStorage.setItem(STORAGE_KEYS.MESSAGES, JSON.stringify(restoredMessages));
-              sessionStorage.setItem(STORAGE_KEYS.SESSION_ID, conversationManagerRef.current.conversationId);
+              _storeSet(STORAGE_KEYS.MESSAGES, JSON.stringify(restoredMessages));
+              _storeSet(STORAGE_KEYS.SESSION_ID, conversationManagerRef.current.conversationId);
 
               errorLogger.logInfo('✅ Synchronized UI with server messages', {
                 sessionId: conversationManagerRef.current.conversationId,
@@ -1095,7 +1096,7 @@ const ChatProvider = ({ children }) => {
           } else {
             // No messages from server - ensure we're not showing stale messages
             const currentSessionId = conversationManagerRef.current?.conversationId || sessionIdRef.current;
-            const storedSessionId = sessionStorage.getItem(STORAGE_KEYS.SESSION_ID);
+            const storedSessionId = _storeGet(STORAGE_KEYS.SESSION_ID);
 
             if (storedSessionId && storedSessionId !== currentSessionId) {
               logger.debug('🧹 Clearing stale messages from different session', {
@@ -1103,7 +1104,7 @@ const ChatProvider = ({ children }) => {
                 currentSession: currentSessionId?.slice(0, 12)
               });
               setMessages([]);
-              sessionStorage.removeItem(STORAGE_KEYS.MESSAGES);
+              _storeRemove(STORAGE_KEYS.MESSAGES);
             }
           }
 
@@ -1179,9 +1180,9 @@ const ChatProvider = ({ children }) => {
       console.log('🔴 WIDGET CLOSING - ChatProvider unmounting');
       console.log('🔴 Current messages in state:', messages.length);
       console.log('🔴 SessionStorage contents:', {
-        sessionId: sessionStorage.getItem(STORAGE_KEYS.SESSION_ID),
-        messagesExist: !!sessionStorage.getItem(STORAGE_KEYS.MESSAGES),
-        messageCount: JSON.parse(sessionStorage.getItem(STORAGE_KEYS.MESSAGES) || '[]').length
+        sessionId: _storeGet(STORAGE_KEYS.SESSION_ID),
+        messagesExist: !!_storeGet(STORAGE_KEYS.MESSAGES),
+        messageCount: JSON.parse(_storeGet(STORAGE_KEYS.MESSAGES) || '[]').length
       });
       console.log('🔴 ConversationManager state:', {
         exists: !!conversationManagerRef.current,
@@ -2343,7 +2344,7 @@ const ChatProvider = ({ children }) => {
     }
     
     // Clear session storage to prevent message restoration
-    sessionStorage.removeItem(STORAGE_KEYS.MESSAGES);
+    _storeRemove(STORAGE_KEYS.MESSAGES);
     
     // Abort any in-flight requests
     abortControllersRef.current.forEach(controller => {

--- a/Picasso/src/context/ConfigProvider.jsx
+++ b/Picasso/src/context/ConfigProvider.jsx
@@ -1,5 +1,6 @@
 import { createContext, useState, useEffect, useRef, useContext } from 'react';
 import { config as environmentConfig } from '../config/environment';
+import { _storeGet, _storeSet } from './shared/messageHelpers';
 
 const ConfigContext = createContext();
 
@@ -71,8 +72,9 @@ const ConfigProvider = ({ children }) => {
         tenantHash
       });
 
-      // Check if there's a local config path override (for local testing)
-      if (typeof window !== 'undefined' && window.PICASSO_CONFIG_PATH) {
+      // Check if there's a local config path override (dev builds only — gated by build flag)
+      if (typeof __ALLOW_CONFIG_PATH_OVERRIDE__ !== 'undefined' && __ALLOW_CONFIG_PATH_OVERRIDE__ &&
+          typeof window !== 'undefined' && window.PICASSO_CONFIG_PATH) {
         console.log('🔧 Using local config path override:', window.PICASSO_CONFIG_PATH);
         const response = await fetch(window.PICASSO_CONFIG_PATH);
         console.log('📡 Local config fetch response:', response.status, response.ok);
@@ -96,7 +98,7 @@ const ConfigProvider = ({ children }) => {
       
       // Check cache first with version validation
       const cacheKey = `picasso-config-${tenantHash}`;
-      const cachedData = sessionStorage.getItem(cacheKey);
+      const cachedData = _storeGet(cacheKey);
       
       if (!force && cachedData) {
         const cached = JSON.parse(cachedData);
@@ -210,7 +212,7 @@ const ConfigProvider = ({ children }) => {
         version: version,
         timestamp: Date.now()
       };
-      sessionStorage.setItem(`picasso-config-${tenantHash}`, JSON.stringify(cacheData));
+      _storeSet(`picasso-config-${tenantHash}`, JSON.stringify(cacheData));
 
       console.log('✅ Config loaded successfully from Lambda Master_Function', {
         hash: tenantHash.slice(0, 8) + '...',

--- a/Picasso/src/context/FormModeContext.jsx
+++ b/Picasso/src/context/FormModeContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
 import { useConfig } from '../hooks/useConfig';
+import { _storeGet, _storeSet, _storeRemove, _storeKeys } from './shared/messageHelpers';
 import {
   FORM_VIEWED,
   FORM_STARTED,
@@ -58,10 +59,10 @@ export const FormModeProvider = ({ children }) => {
 
   // Session storage key prefix
   const STORAGE_PREFIX = 'picasso_form_';
-  const SESSION_ID = sessionStorage.getItem('picasso_session_id') ||
+  const SESSION_ID = _storeGet('picasso_session_id') ||
                       (() => {
                         const id = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-                        sessionStorage.setItem('picasso_session_id', id);
+                        _storeSet('picasso_session_id', id);
                         return id;
                       })();
 
@@ -69,17 +70,17 @@ export const FormModeProvider = ({ children }) => {
   useEffect(() => {
     const loadSuspendedForms = () => {
       const forms = new Map();
-      for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
+      const allKeys = _storeKeys();
+      for (const key of allKeys) {
         if (key && key.startsWith(STORAGE_PREFIX)) {
           try {
-            const data = JSON.parse(sessionStorage.getItem(key));
+            const data = JSON.parse(_storeGet(key));
             // Check if form is still valid (30 minute TTL)
             if (data.suspendedAt && Date.now() - data.suspendedAt < 30 * 60 * 1000) {
               forms.set(data.formId, data);
             } else {
               // Clean up expired forms
-              sessionStorage.removeItem(key);
+              _storeRemove(key);
             }
           } catch (e) {
             console.error('Error loading suspended form:', e);
@@ -465,7 +466,7 @@ export const FormModeProvider = ({ children }) => {
 
     // Save to session storage
     const storageKey = `${STORAGE_PREFIX}${currentFormId}_${SESSION_ID}`;
-    sessionStorage.setItem(storageKey, JSON.stringify(suspendedData));
+    _storeSet(storageKey, JSON.stringify(suspendedData));
 
     // Update suspended forms map
     setSuspendedForms(prev => new Map(prev).set(currentFormId, suspendedData));
@@ -508,7 +509,7 @@ export const FormModeProvider = ({ children }) => {
 
     // Clear from session storage
     const storageKey = `${STORAGE_PREFIX}${formId}_${SESSION_ID}`;
-    sessionStorage.removeItem(storageKey);
+    _storeRemove(storageKey);
 
     return true;
   }, [suspendedForms]);
@@ -543,7 +544,7 @@ export const FormModeProvider = ({ children }) => {
 
     // Clear from session storage if suspended
     const storageKey = `${STORAGE_PREFIX}${currentFormId}_${SESSION_ID}`;
-    sessionStorage.removeItem(storageKey);
+    _storeRemove(storageKey);
 
     // Reset all form state
     setIsFormMode(false);

--- a/Picasso/src/context/HTTPChatProvider.jsx
+++ b/Picasso/src/context/HTTPChatProvider.jsx
@@ -24,7 +24,11 @@ import {
   getTenantHash,
   saveToSession,
   getFromSession,
-  clearSession
+  clearSession,
+  _storeGet,
+  _storeSet,
+  _storeRemove,
+  _storeKeys
 } from './shared/messageHelpers';
 import { logger } from '../utils/logger';
 import { config as envConfig } from '../config/environment';
@@ -172,10 +176,10 @@ export default function HTTPChatProvider({ children }) {
             });
 
             // Clear stale session
-            sessionStorage.removeItem('picasso_session_id');
-            sessionStorage.removeItem('picasso_messages');
-            sessionStorage.removeItem('picasso_session_context');
-            sessionStorage.removeItem('picasso_session_timestamp');
+            _storeRemove('picasso_session_id');
+            _storeRemove('picasso_messages');
+            _storeRemove('picasso_session_context');
+            _storeRemove('picasso_session_timestamp');
 
             // Start fresh
             sessionIdRef.current = generateSessionId();
@@ -447,11 +451,10 @@ export default function HTTPChatProvider({ children }) {
       const suspendedForms = [];
       let suspendedProgramInterest = null; // Track program_interest from volunteer form
 
-      for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
+      for (const key of _storeKeys()) {
         if (key && key.startsWith('picasso_form_')) {
           try {
-            const formState = JSON.parse(sessionStorage.getItem(key));
+            const formState = JSON.parse(_storeGet(key));
             if (formState && formState.formId) {
               suspendedForms.push(formState.formId);
 
@@ -600,8 +603,7 @@ export default function HTTPChatProvider({ children }) {
 
         // Check sessionStorage for suspended forms
         const suspendedFormKeys = [];
-        for (let i = 0; i < sessionStorage.length; i++) {
-          const key = sessionStorage.key(i);
+        for (const key of _storeKeys()) {
           if (key && key.startsWith('picasso_form_')) {
             suspendedFormKeys.push(key);
           }
@@ -615,7 +617,7 @@ export default function HTTPChatProvider({ children }) {
 
         if (suspendedFormKeys.length > 0) {
           // Get the first suspended form
-          const formStateStr = sessionStorage.getItem(suspendedFormKeys[0]);
+          const formStateStr = _storeGet(suspendedFormKeys[0]);
           if (formStateStr) {
             try {
               const formState = JSON.parse(formStateStr);

--- a/Picasso/src/context/StreamingChatProvider.jsx
+++ b/Picasso/src/context/StreamingChatProvider.jsx
@@ -23,7 +23,9 @@ import {
   getTenantHash,
   saveToSession,
   getFromSession,
-  clearSession
+  clearSession,
+  _storeGet,
+  _storeKeys
 } from './shared/messageHelpers';
 import { logger } from '../utils/logger';
 import { config as envConfig } from '../config/environment';
@@ -415,7 +417,7 @@ export default function StreamingChatProvider({ children }) {
           });
 
           // Check raw sessionStorage to see what's actually stored
-          const rawStoredItem = sessionStorage.getItem('picasso_messages');
+          const rawStoredItem = _storeGet('picasso_messages');
           if (rawStoredItem) {
             try {
               const parsedRaw = JSON.parse(rawStoredItem);
@@ -957,13 +959,7 @@ export default function StreamingChatProvider({ children }) {
 
           setTimeout(() => {
             // Check sessionStorage for suspended forms
-            const suspendedFormKeys = [];
-            for (let i = 0; i < sessionStorage.length; i++) {
-              const key = sessionStorage.key(i);
-              if (key && key.startsWith('picasso_form_')) {
-                suspendedFormKeys.push(key);
-              }
-            }
+            const suspendedFormKeys = _storeKeys().filter(key => key.startsWith('picasso_form_'));
 
             console.log('[StreamingChatProvider] Checking for suspended forms after response:', {
               suspendedFormKeys,
@@ -973,7 +969,7 @@ export default function StreamingChatProvider({ children }) {
 
             if (suspendedFormKeys.length > 0) {
               // Get the first suspended form
-              const formStateStr = sessionStorage.getItem(suspendedFormKeys[0]);
+              const formStateStr = _storeGet(suspendedFormKeys[0]);
               if (formStateStr) {
                 const formState = JSON.parse(formStateStr);
                 const formId = formState.formId;

--- a/Picasso/src/context/shared/messageHelpers.js
+++ b/Picasso/src/context/shared/messageHelpers.js
@@ -165,9 +165,45 @@ export const getTenantHash = () => {
 };
 
 /**
- * Session storage helpers with expiration
+ * Session storage helpers with expiration.
+ * Falls back to an in-memory Map when sessionStorage is unavailable
+ * (e.g. inside a sandboxed iframe without allow-same-origin).
  */
 const SESSION_EXPIRY = 30 * 60 * 1000; // 30 minutes
+
+// In-memory fallback when sessionStorage is inaccessible
+const _memoryStore = new Map();
+
+const _hasSessionStorage = (() => {
+  try {
+    const key = '__picasso_ss_test__';
+    sessionStorage.setItem(key, '1');
+    sessionStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const _storeGet = (key) => {
+  if (_hasSessionStorage) return sessionStorage.getItem(key);
+  return _memoryStore.get(key) ?? null;
+};
+
+const _storeSet = (key, value) => {
+  if (_hasSessionStorage) { sessionStorage.setItem(key, value); return; }
+  _memoryStore.set(key, value);
+};
+
+const _storeRemove = (key) => {
+  if (_hasSessionStorage) { sessionStorage.removeItem(key); return; }
+  _memoryStore.delete(key);
+};
+
+const _storeKeys = () => {
+  if (_hasSessionStorage) return Object.keys(sessionStorage);
+  return Array.from(_memoryStore.keys());
+};
 
 export const saveToSession = (key, value) => {
   try {
@@ -175,7 +211,7 @@ export const saveToSession = (key, value) => {
       value,
       timestamp: Date.now()
     };
-    sessionStorage.setItem(key, JSON.stringify(data));
+    _storeSet(key, JSON.stringify(data));
   } catch (error) {
     console.warn('Failed to save to session storage:', error);
   }
@@ -183,7 +219,7 @@ export const saveToSession = (key, value) => {
 
 export const getFromSession = (key) => {
   try {
-    const item = sessionStorage.getItem(key);
+    const item = _storeGet(key);
     if (!item) return null;
 
     const data = JSON.parse(item);
@@ -192,7 +228,7 @@ export const getFromSession = (key) => {
     if (typeof data !== 'object' || !data.hasOwnProperty('timestamp') || !data.hasOwnProperty('value')) {
       // Invalid structure - clean up and return null
       console.warn(`[getFromSession] Invalid data structure for key "${key}" - cleaning up`);
-      sessionStorage.removeItem(key);
+      _storeRemove(key);
       return null;
     }
 
@@ -209,7 +245,7 @@ export const getFromSession = (key) => {
     const age = Date.now() - data.timestamp;
 
     if (age > SESSION_EXPIRY) {
-      sessionStorage.removeItem(key);
+      _storeRemove(key);
       return null;
     }
 
@@ -218,7 +254,7 @@ export const getFromSession = (key) => {
     // JSON parse error or other issue - clean up the corrupted data
     console.warn(`[getFromSession] Failed to read from session storage for key "${key}":`, error.message);
     try {
-      sessionStorage.removeItem(key);
+      _storeRemove(key);
     } catch (removeError) {
       // Silently fail if we can't remove
     }
@@ -229,14 +265,17 @@ export const getFromSession = (key) => {
 export const clearSession = () => {
   try {
     const keysToKeep = ['picasso_config_cache']; // Keep config cache
-    const allKeys = Object.keys(sessionStorage);
-    
+    const allKeys = _storeKeys();
+
     allKeys.forEach(key => {
       if (key.startsWith('picasso_') && !keysToKeep.includes(key)) {
-        sessionStorage.removeItem(key);
+        _storeRemove(key);
       }
     });
   } catch (error) {
     console.warn('Failed to clear session storage:', error);
   }
 };
+
+// Export storage helpers for direct callers that bypass saveToSession/getFromSession
+export { _storeGet, _storeSet, _storeRemove, _storeKeys };

--- a/Picasso/src/iframe-main.jsx
+++ b/Picasso/src/iframe-main.jsx
@@ -10,6 +10,7 @@ import ChatWidget from './components/chat/ChatWidget.jsx';
 import { CSSVariablesProvider } from './components/chat/useCSSVariables.js';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
 import { config as environmentConfig } from './config/environment.js';
+import { _storeGet, _storeSet } from './context/shared/messageHelpers.js';
 import { setHostViewportWidth } from './utils/resolveWidgetBehavior.js';
 import { setupGlobalErrorHandling, performanceMonitor } from './utils/errorHandling.js';
 import { performanceTracker } from './utils/performanceTracking.js';
@@ -257,7 +258,7 @@ async function flushEventsToBackend() {
   // Get the streaming endpoint (Bedrock Streaming Handler)
   const streamingEndpoint = environmentConfig.getStreamingEndpoint?.() ||
                             environmentConfig.STREAMING_ENDPOINT ||
-                            'https://7pluzq3axftklmb4gbgchfdahu0lcnqd.lambda-url.us-east-1.on.aws';
+                            '';
 
   // Build analytics endpoint URL
   const analyticsEndpoint = `${streamingEndpoint}?action=analytics`;
@@ -490,7 +491,7 @@ function initializeWidget() {
       try {
         // Check for cached config first (performance optimization)
         const cacheKey = `picasso_config_${tenantHash}`;
-        const cached = sessionStorage.getItem(cacheKey);
+        const cached = _storeGet(cacheKey);
         if (cached) {
           try {
             const cachedConfig = JSON.parse(cached);
@@ -550,7 +551,7 @@ function initializeWidget() {
         // Cache the config with timestamp
         config._cached = Date.now();
         try {
-          sessionStorage.setItem(cacheKey, JSON.stringify(config));
+          _storeSet(cacheKey, JSON.stringify(config));
         } catch (e) {
           console.warn('Failed to cache config:', e);
         }

--- a/Picasso/src/utils/conversationManager.js
+++ b/Picasso/src/utils/conversationManager.js
@@ -8,6 +8,7 @@
 import { config as environmentConfig } from '../config/environment';
 import { errorLogger, performanceMonitor } from './errorHandling';
 import { createLogger } from './logger';
+import { _storeGet, _storeSet, _storeRemove } from '../context/shared/messageHelpers';
 
 const logger = createLogger('ConversationManager');
 
@@ -42,7 +43,7 @@ export class ConversationManager {
     this.sessionId = sessionId;
     
     // Check for existing conversation ID in sessionStorage for conversation recall
-    const existingConversationId = sessionStorage.getItem('picasso_conversation_id');
+    const existingConversationId = _storeGet('picasso_conversation_id');
     if (existingConversationId && existingConversationId.startsWith('session_')) {
       this.conversationId = existingConversationId;
       logger.debug('♻️ Using existing conversation ID from storage:', this.conversationId);
@@ -546,7 +547,7 @@ export class ConversationManager {
         
         // Persist conversation ID to sessionStorage for conversation recall
         try {
-          sessionStorage.setItem('picasso_conversation_id', this.conversationId);
+          _storeSet('picasso_conversation_id', this.conversationId);
           logger.debug('💾 Persisted conversation ID to sessionStorage');
         } catch (e) {
           logger.warn('Failed to persist conversation ID:', e);
@@ -1197,7 +1198,7 @@ export class ConversationManager {
   // Token management methods
   loadStateToken() {
     try {
-      const stored = sessionStorage.getItem(CONVERSATION_CONFIG.TOKEN_STORAGE_KEY);
+      const stored = _storeGet(CONVERSATION_CONFIG.TOKEN_STORAGE_KEY);
       if (stored) {
         const tokenData = JSON.parse(stored);
         // Check if token is still valid (basic expiry check)
@@ -1224,7 +1225,7 @@ export class ConversationManager {
         expires: new Date(Date.now() + CONVERSATION_CONFIG.CACHE_DURATION).toISOString()
       };
       
-      sessionStorage.setItem(
+      _storeSet(
         CONVERSATION_CONFIG.TOKEN_STORAGE_KEY,
         JSON.stringify(tokenData)
       );
@@ -1236,7 +1237,7 @@ export class ConversationManager {
   clearStateToken() {
     try {
       this.stateToken = null;
-      sessionStorage.removeItem(CONVERSATION_CONFIG.TOKEN_STORAGE_KEY);
+      _storeRemove(CONVERSATION_CONFIG.TOKEN_STORAGE_KEY);
     } catch (error) {
       errorLogger.logError(error, { context: 'clear_state_token' });
     }
@@ -1380,7 +1381,7 @@ export class ConversationManager {
         savedAt: Date.now()
       };
       
-      sessionStorage.setItem(
+      _storeSet(
         CONVERSATION_CONFIG.SESSION_STORAGE_KEY,
         JSON.stringify(sessionData)
       );
@@ -1392,7 +1393,7 @@ export class ConversationManager {
   
   loadFromSessionStorage() {
     try {
-      const stored = sessionStorage.getItem(CONVERSATION_CONFIG.SESSION_STORAGE_KEY);
+      const stored = _storeGet(CONVERSATION_CONFIG.SESSION_STORAGE_KEY);
       if (!stored) return null;
       
       const data = JSON.parse(stored);
@@ -1443,7 +1444,7 @@ export class ConversationManager {
   
   clearSessionStorage() {
     try {
-      sessionStorage.removeItem(CONVERSATION_CONFIG.SESSION_STORAGE_KEY);
+      _storeRemove(CONVERSATION_CONFIG.SESSION_STORAGE_KEY);
     } catch (error) {
       errorLogger.logError(error, { context: 'clear_session_storage' });
     }

--- a/Picasso/src/widget-host.js
+++ b/Picasso/src/widget-host.js
@@ -235,8 +235,8 @@ import { config as environmentConfig } from './config/environment.js';
         src: iframeUrl,
         id: 'picasso-widget-iframe',
         title: 'Picasso Chat Widget',
-        allow: 'camera *; microphone *; geolocation *'
-        // Removed sandbox attribute to avoid security warning - iframe provides sufficient isolation
+        allow: 'camera *; microphone *; geolocation *',
+        sandbox: 'allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox'
       });
       
       // Style iframe for seamless integration
@@ -404,8 +404,7 @@ import { config as environmentConfig } from './config/environment.js';
       this.analyticsQueue = [];
 
       // Get streaming endpoint from config or use default
-      const streamingEndpoint = this.config?.streamingEndpoint ||
-                                'https://7pluzq3axftklmb4gbgchfdahu0lcnqd.lambda-url.us-east-1.on.aws';
+      const streamingEndpoint = this.config?.streamingEndpoint || '';
       const analyticsEndpoint = `${streamingEndpoint}?action=analytics`;
 
       console.log('📊 [Analytics Host] Flushing', events.length, 'events');

--- a/Picasso/src/widget-host.js
+++ b/Picasso/src/widget-host.js
@@ -236,7 +236,7 @@ import { config as environmentConfig } from './config/environment.js';
         id: 'picasso-widget-iframe',
         title: 'Picasso Chat Widget',
         allow: 'camera *; microphone *; geolocation *',
-        sandbox: 'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox'
+        sandbox: 'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation'
       });
       
       // Style iframe for seamless integration

--- a/Picasso/src/widget-host.js
+++ b/Picasso/src/widget-host.js
@@ -236,7 +236,7 @@ import { config as environmentConfig } from './config/environment.js';
         id: 'picasso-widget-iframe',
         title: 'Picasso Chat Widget',
         allow: 'camera *; microphone *; geolocation *',
-        sandbox: 'allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox'
+        sandbox: 'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox'
       });
       
       // Style iframe for seamless integration


### PR DESCRIPTION
## Summary
- CloudFront `/stream` behavior routes to Lambda streaming handler as custom origin
- WAF attached: rate limiting (300 req/5min per IP), AWS managed rule sets (common, bad inputs, IP reputation), 50KB body limit
- Staging and production streaming endpoints changed from raw Lambda URLs to CloudFront paths
- No more Lambda Function URLs exposed directly to the internet

## Infrastructure changes (already applied to staging)
- CloudFront `E1CGYA1AJ9OYL0` (staging): new origin `picasso-streaming-lambda`, `/stream*` behavior, WAF `picasso-streaming-waf`
- Production `E3G0LSWB1AQ9LP`: pending (will apply after staging verification)

## Test plan
- [ ] Staging: open https://staging.chat.myrecruiter.ai/test-staging.html, send a message, verify streaming response
- [ ] Verify `curl -X POST https://staging.chat.myrecruiter.ai/stream -d '{"action":"health"}'` returns 200
- [ ] Production: apply CloudFront config after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)