### PR TITLE
feat: Route streaming through CloudFront (P22 Phase 2)

### DIFF
--- a/Picasso/esbuild.config.mjs
+++ b/Picasso/esbuild.config.mjs
@@ -146,10 +146,10 @@ const ENVIRONMENT_CONFIG = {
     CHAT_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=chat',
     CONVERSATION_ENDPOINT: process.env.PICASSO_STAGING_CONVERSATION_ENDPOINT || 'https://staging.chat.myrecruiter.ai/Master_Function?action=conversation',
     ERROR_REPORTING_ENDPOINT: 'https://staging.chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: process.env.PICASSO_STAGING_STREAMING_ENDPOINT || ''
+    STREAMING_ENDPOINT: 'https://staging.chat.myrecruiter.ai/stream'
   },
   production: {
-    // Production uses API Gateway/CloudFront for main endpoints, Lambda URLs from CI secrets
+    // Production: all traffic through CloudFront (chat.myrecruiter.ai)
     API_BASE_URL: 'https://chat.myrecruiter.ai/Master_Function',
     WIDGET_DOMAIN: 'https://chat.myrecruiter.ai',
     CONFIG_DOMAIN: 'https://picassocode.s3.amazonaws.com',
@@ -157,7 +157,7 @@ const ENVIRONMENT_CONFIG = {
     CHAT_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=chat',
     CONVERSATION_ENDPOINT: process.env.PICASSO_CONVERSATION_ENDPOINT || '',
     ERROR_REPORTING_ENDPOINT: 'https://chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: process.env.PICASSO_STREAMING_ENDPOINT || ''
+    STREAMING_ENDPOINT: 'https://chat.myrecruiter.ai/stream'
   }
 };
 

--- a/Picasso/src/config/environment.js
+++ b/Picasso/src/config/environment.js
@@ -226,7 +226,7 @@ const ENVIRONMENTS = {
     CHAT_ENDPOINT: typeof __CHAT_ENDPOINT__ !== 'undefined' ? __CHAT_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=chat',
     CONVERSATION_ENDPOINT: typeof __CONVERSATION_ENDPOINT__ !== 'undefined' ? __CONVERSATION_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=conversation',
     ERROR_REPORTING_ENDPOINT: typeof __ERROR_REPORTING_ENDPOINT__ !== 'undefined' ? __ERROR_REPORTING_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : '', // Set via CI secrets
+    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : 'https://staging.chat.myrecruiter.ai/stream',
     STREAMING_METHOD: 'POST', // Lambda expects POST requests with JSON body
     DEFAULT_TENANT_HASH: typeof __DEFAULT_TENANT_HASH__ !== 'undefined' ? __DEFAULT_TENANT_HASH__ : 'my87674d777bf9', // MyRecruiter tenant: ID=MYR384719, Hash=my87674d777bf9
 
@@ -255,7 +255,7 @@ const ENVIRONMENTS = {
     // Use Lambda Function URL for conversation to preserve JWT headers (CloudFront strips them)
     CONVERSATION_ENDPOINT: typeof __CONVERSATION_ENDPOINT__ !== 'undefined' ? __CONVERSATION_ENDPOINT__ : '', // Set via CI secrets
     ERROR_REPORTING_ENDPOINT: typeof __ERROR_REPORTING_ENDPOINT__ !== 'undefined' ? __ERROR_REPORTING_ENDPOINT__ : 'https://chat.myrecruiter.ai/Master_Function?action=log_error',
-    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : '', // Set via CI secrets
+    STREAMING_ENDPOINT: typeof __STREAMING_ENDPOINT__ !== 'undefined' ? __STREAMING_ENDPOINT__ : 'https://chat.myrecruiter.ai/stream',
     STREAMING_METHOD: 'POST', // Lambda expects POST requests with JSON body
     DEFAULT_TENANT_HASH: typeof __DEFAULT_TENANT_HASH__ !== 'undefined' ? __DEFAULT_TENANT_HASH__ : 'my87674d777bf9', // MyRecruiter default tenant for production
     


### PR DESCRIPTION
## Summary
- Streaming endpoints changed from raw Lambda Function URLs to CloudFront paths (`/stream`)
- Staging: `https://staging.chat.myrecruiter.ai/stream`
- Production: `https://chat.myrecruiter.ai/stream`
- Existing CI streaming secrets now unused (cleanup deferred to Step 6 after production verification)

## Plan
Approved plan: `docs/roadmap/P22_CLOUDFRONT_WAF_PLAN.md`
This PR covers **Step 1** only.

## Test plan
- [ ] CI quality gates pass
- [ ] Staging deploy completes
- [ ] E2E staging verification (Step 3): chat, streaming, CTAs at `staging.chat.myrecruiter.ai/test-staging.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)