### PR TITLE
chore: Remove unused streaming endpoint CI secrets (P22 Step 6)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -204,7 +204,6 @@ jobs:
         env:
           BUILD_ENV: production
           PICASSO_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_CONVERSATION_ENDPOINT }}
-          PICASSO_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STREAMING_ENDPOINT }}
 
       - name: Validate no dev/staging Lambda URLs in production build
         working-directory: ./Picasso
@@ -281,7 +280,6 @@ jobs:
         env:
           BUILD_ENV: staging
           PICASSO_STAGING_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_STAGING_CONVERSATION_ENDPOINT }}
-          PICASSO_STAGING_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STAGING_STREAMING_ENDPOINT }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -363,7 +361,6 @@ jobs:
         env:
           BUILD_ENV: production
           PICASSO_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_CONVERSATION_ENDPOINT }}
-          PICASSO_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STREAMING_ENDPOINT }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -146,7 +146,6 @@ jobs:
         env:
           BUILD_ENV: production
           PICASSO_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_CONVERSATION_ENDPOINT }}
-          PICASSO_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STREAMING_ENDPOINT }}
 
       - name: Validate no dev/staging Lambda URLs in production build
         working-directory: ./Picasso
@@ -206,7 +205,6 @@ jobs:
         env:
           BUILD_ENV: staging
           PICASSO_STAGING_CONVERSATION_ENDPOINT: ${{ secrets.PICASSO_STAGING_CONVERSATION_ENDPOINT }}
-          PICASSO_STAGING_STREAMING_ENDPOINT: ${{ secrets.PICASSO_STAGING_STREAMING_ENDPOINT }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary
- Remove `PICASSO_STREAMING_ENDPOINT` and `PICASSO_STAGING_STREAMING_ENDPOINT` env passthrough from both CI workflows
- Secrets already deleted from GitHub
- Streaming now uses hardcoded CloudFront paths, no secrets needed

## Test plan
- [ ] CI passes without the streaming secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)